### PR TITLE
Replaced int to long

### DIFF
--- a/pymrmr/pymrmr.pyx
+++ b/pymrmr/pymrmr.pyx
@@ -16,7 +16,7 @@ cdef extern from 'mrmr.cpp':
     unsigned long _nfeats) except +
 
 def mRMR(data, method, nfeats):
-  cdef vector[vector[int]] _data = data.copy().values
+  cdef vector[vector[long]] _data = data.copy().values
   cdef vector[string] _names = [s.encode('utf-8') for s in data.columns]
 
   if method == 'MID': _method = 0

--- a/pymrmr/pymrmr.pyx
+++ b/pymrmr/pymrmr.pyx
@@ -10,7 +10,7 @@ __version__ = '0.1.1'
 
 cdef extern from 'mrmr.cpp':
   cdef vector[unsigned long] _mRMR(
-    vector[vector[int]] _data,
+    vector[vector[long]] _data,
     vector[string] _names,
     int _method,
     unsigned long _nfeats) except +


### PR DESCRIPTION
To resolve the TypeError: an integer is required, I changed the value's input type to long, so that it can now support both float and int values.